### PR TITLE
Issue #12 & #26 - startup fails when using JAVA_OPTIONS

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,19 +89,23 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
 		set -- $(cat $JETTY_START)
 	else
-		# Do a jetty dry run to set the final command
+		# Do a jetty dry run to set the final command.
 		JAVA="$1"
 		shift
-		$JAVA "$@" --dry-run > $JETTY_START
-		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
-			# command was more than a dry-run
-		    echo "jetty.start contained unexpected lines:"
-			cat $JETTY_START \
-			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
-			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
+		DRY_RUN=$($JAVA $JAVA_OPTIONS "$@" --dry-run)
+		echo "$DRY_RUN" \
+		    | egrep '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+		    | sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//' \
+		    > $JETTY_START
+
+		# If jetty.start doesn't have content then the dry-run failed.
+		if ! [ -s $JETTY_START ]; then
+		    echo "jetty dry run failed:"
+			echo DRY_RUN | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
 			exit
 		fi
-		set -- $(sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//' $JETTY_START)
+
+		set -- $(cat $JETTY_START)
 	fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,9 +92,10 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 		# Do a jetty dry run to set the final command
 		JAVA="$1"
 		shift
-		$JAVA $JAVA_OPTIONS "$@" --dry-run > $JETTY_START
+		$JAVA "$@" --dry-run > $JETTY_START
 		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
 			# command was more than a dry-run
+		    echo "jetty.start contained unexpected lines:"
 			cat $JETTY_START \
 			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
 			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -4,4 +4,4 @@ if [ -z "$JETTY_START" ] ; then
 	JETTY_START=$JETTY_BASE/jetty.start
 fi
 rm -f $JETTY_START
-/docker-entrypoint.sh --dry-run
+/docker-entrypoint.sh --dry-run | sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//' > $JETTY_START

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -4,4 +4,4 @@ if [ -z "$JETTY_START" ] ; then
 	JETTY_START=$JETTY_BASE/jetty.start
 fi
 rm -f $JETTY_START
-/docker-entrypoint.sh --dry-run | sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//' > $JETTY_START
+/docker-entrypoint.sh --dry-run


### PR DESCRIPTION
**Closes #26 & #12** 

The `docker-entrypoint.sh` script fails if the output of the dry run has more than one line. Using some `JAVA_OPTIONS` will add some extra lines to the output which will cause the entrypoint script to fail without an error message.

I have changed the script so that it filters the output of the `--dry-run` to get the start command and discards the rest of the output. If the start command can't be found it then gives an error and prints the output of the dry run.