### PR TITLE
Issue #69 - add more generic image tags for Jetty 10 & 11 versions 

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -17,7 +17,7 @@ isDefaultVersion() {
 
 declare -A aliases
 aliases=(
-	[9.4-jdk17]='9 latest jdk17'
+	[9.4-jdk17]='latest jdk17'
 	[9.3-jre8]='9.3'
 	[9.2-jre8]='9.2'
 )


### PR DESCRIPTION
## Closes #69

Add more generic image tags for Jetty 10 & 11 versions. The full list of image tags were only being generated for versions at or below Jetty 9.4. Here is the new output from `./generate-stackbrew-library.sh`:

```
Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
             Lachlan Roberts <lachlan@webtide.com> (@lachlan-roberts),
             Olivier Lamy <olamy@webtide.com> (@olamy),
             Joakim Erdfelt <joakim@webtide.com> (@joakime)
GitRepo: https://github.com/eclipse/jetty.docker.git

Tags: 11.0.6-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
Architectures: amd64, arm64v8
Directory: 11.0-jre11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 11.0.6-jre11, 11.0-jre11, 11-jre11
Architectures: amd64, arm64v8
Directory: 11.0-jre11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 11.0.6-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
Architectures: amd64, arm64v8
Directory: 11.0-jdk17-slim
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 11.0.6, 11.0, 11, 11.0.6-jdk17, 11.0-jdk17, 11-jdk17
Architectures: amd64, arm64v8
Directory: 11.0-jdk17
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 11.0.6-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
Architectures: amd64, arm64v8
Directory: 11.0-jdk11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 11.0.6-jdk11, 11.0-jdk11, 11-jdk11
Architectures: amd64, arm64v8
Directory: 11.0-jdk11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 10.0.6-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
Architectures: amd64, arm64v8
Directory: 10.0-jre11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 10.0.6-jre11, 10.0-jre11, 10-jre11
Architectures: amd64, arm64v8
Directory: 10.0-jre11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 10.0.6-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
Architectures: amd64, arm64v8
Directory: 10.0-jdk17-slim
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 10.0.6, 10.0, 10, 10.0.6-jdk17, 10.0-jdk17, 10-jdk17
Architectures: amd64, arm64v8
Directory: 10.0-jdk17
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 10.0.6-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
Architectures: amd64, arm64v8
Directory: 10.0-jdk11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 10.0.6-jdk11, 10.0-jdk11, 10-jdk11
Architectures: amd64, arm64v8
Directory: 10.0-jdk11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
Architectures: amd64, arm64v8
Directory: 9.4-jre11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jre11, 9.4-jre11, 9-jre11
Architectures: amd64, arm64v8
Directory: 9.4-jre11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
Architectures: amd64, arm64v8
Directory: 9.4-jre8-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jre8, 9.4-jre8, 9-jre8
Architectures: amd64, arm64v8
Directory: 9.4-jre8
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
Architectures: amd64, arm64v8
Directory: 9.4-jdk17-slim
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 9.4.43, 9.4, 9, 9.4.43-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
Architectures: amd64, arm64v8
Directory: 9.4-jdk17
GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a

Tags: 9.4.43-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
Architectures: amd64, arm64v8
Directory: 9.4-jdk11-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jdk11, 9.4-jdk11, 9-jdk11
Architectures: amd64, arm64v8
Directory: 9.4-jdk11
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
Architectures: amd64, arm64v8
Directory: 9.4-jdk8-slim
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.4.43-jdk8, 9.4-jdk8, 9-jdk8
Architectures: amd64, arm64v8
Directory: 9.4-jdk8
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.3.29-jre8, 9.3-jre8, 9.3
Architectures: amd64, arm64v8
Directory: 9.3-jre8
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb

Tags: 9.2.30-jre8, 9.2-jre8, 9.2
Architectures: amd64, arm64v8
Directory: 9.2-jre8
GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
```