### PR TITLE
Update to use new keyserver recommendations

### DIFF
--- a/amazoncorretto/10.0/jdk11-alpine/Dockerfile
+++ b/amazoncorretto/10.0/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/10.0/jdk11/Dockerfile
+++ b/amazoncorretto/10.0/jdk11/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/10.0/jdk17-alpine/Dockerfile
+++ b/amazoncorretto/10.0/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/10.0/jdk17/Dockerfile
+++ b/amazoncorretto/10.0/jdk17/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/11.0/jdk11-alpine/Dockerfile
+++ b/amazoncorretto/11.0/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/11.0/jdk11/Dockerfile
+++ b/amazoncorretto/11.0/jdk11/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/11.0/jdk17-alpine/Dockerfile
+++ b/amazoncorretto/11.0/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/11.0/jdk17/Dockerfile
+++ b/amazoncorretto/11.0/jdk17/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk11-alpine/Dockerfile
+++ b/amazoncorretto/9.4/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk11/Dockerfile
+++ b/amazoncorretto/9.4/jdk11/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk17-alpine/Dockerfile
+++ b/amazoncorretto/9.4/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk17/Dockerfile
+++ b/amazoncorretto/9.4/jdk17/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk8-alpine/Dockerfile
+++ b/amazoncorretto/9.4/jdk8-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/amazoncorretto/9.4/jdk8/Dockerfile
+++ b/amazoncorretto/9.4/jdk8/Dockerfile
@@ -40,18 +40,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/baseDockerfile
+++ b/baseDockerfile
@@ -36,18 +36,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/baseDockerfile-alpine
+++ b/baseDockerfile-alpine
@@ -38,18 +38,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/baseDockerfile-amazoncorretto
+++ b/baseDockerfile-amazoncorretto
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/baseDockerfile-slim
+++ b/baseDockerfile-slim
@@ -47,18 +47,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/10.0/jdk11-alpine/Dockerfile
+++ b/eclipse-temurin/10.0/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/10.0/jdk11/Dockerfile
+++ b/eclipse-temurin/10.0/jdk11/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/10.0/jdk17-alpine/Dockerfile
+++ b/eclipse-temurin/10.0/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/10.0/jdk17/Dockerfile
+++ b/eclipse-temurin/10.0/jdk17/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/11.0/jdk11-alpine/Dockerfile
+++ b/eclipse-temurin/11.0/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/11.0/jdk11/Dockerfile
+++ b/eclipse-temurin/11.0/jdk11/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/11.0/jdk17-alpine/Dockerfile
+++ b/eclipse-temurin/11.0/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/11.0/jdk17/Dockerfile
+++ b/eclipse-temurin/11.0/jdk17/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/9.4/jdk11-alpine/Dockerfile
+++ b/eclipse-temurin/9.4/jdk11-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/9.4/jdk11/Dockerfile
+++ b/eclipse-temurin/9.4/jdk11/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/9.4/jdk17-alpine/Dockerfile
+++ b/eclipse-temurin/9.4/jdk17-alpine/Dockerfile
@@ -39,18 +39,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/9.4/jdk17/Dockerfile
+++ b/eclipse-temurin/9.4/jdk17/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/eclipse-temurin/9.4/jdk8/Dockerfile
+++ b/eclipse-temurin/9.4/jdk8/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jdk11-slim/Dockerfile
+++ b/openjdk/10.0/jdk11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jdk11/Dockerfile
+++ b/openjdk/10.0/jdk11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jdk17-slim/Dockerfile
+++ b/openjdk/10.0/jdk17-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jdk17/Dockerfile
+++ b/openjdk/10.0/jdk17/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jre11-slim/Dockerfile
+++ b/openjdk/10.0/jre11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/10.0/jre11/Dockerfile
+++ b/openjdk/10.0/jre11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jdk11-slim/Dockerfile
+++ b/openjdk/11.0/jdk11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jdk11/Dockerfile
+++ b/openjdk/11.0/jdk11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jdk17-slim/Dockerfile
+++ b/openjdk/11.0/jdk17-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jdk17/Dockerfile
+++ b/openjdk/11.0/jdk17/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jre11-slim/Dockerfile
+++ b/openjdk/11.0/jre11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/11.0/jre11/Dockerfile
+++ b/openjdk/11.0/jre11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk-8-slim/Dockerfile
+++ b/openjdk/9.4/jdk-8-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk11-slim/Dockerfile
+++ b/openjdk/9.4/jdk11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk11/Dockerfile
+++ b/openjdk/9.4/jdk11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk17-slim/Dockerfile
+++ b/openjdk/9.4/jdk17-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk17/Dockerfile
+++ b/openjdk/9.4/jdk17/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jdk8/Dockerfile
+++ b/openjdk/9.4/jdk8/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jre11-slim/Dockerfile
+++ b/openjdk/9.4/jre11-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jre11/Dockerfile
+++ b/openjdk/9.4/jre11/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jre8-slim/Dockerfile
+++ b/openjdk/9.4/jre8-slim/Dockerfile
@@ -48,18 +48,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME

--- a/openjdk/9.4/jre8/Dockerfile
+++ b/openjdk/9.4/jre8/Dockerfile
@@ -37,18 +37,7 @@ RUN set -xe ; \
 	export GNUPGHOME=/jetty-keys ; \
 	mkdir -p "$GNUPGHOME" ; \
 	for key in $JETTY_GPG_KEYS; do \
-		for server in \
-			ha.pool.sks-keyservers.net \
-			pgp.mit.edu \
-			hkp://p80.pool.sks-keyservers.net:80 \
-			hkp://keyserver.ubuntu.com:80 \
-			keyserver.pgp.com \
-			ipv4.pool.sks-keyservers.net ; \
-		do \
-			if gpg --batch --keyserver "$server" --recv-keys "$key"; then \
-				break; \
-			fi; \
-		done; \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
 	done ; \
 	#
 	# Fetch jetty release into JETTY_HOME


### PR DESCRIPTION
Use new recommendations from https://github.com/docker-library/faq/pull/26#issuecomment-1051372819

> Explicitly, the recommended update is to switch to exclusively either hkps://keys.openpgp.org (if email addresses are or can be verified there) or keyserver.ubuntu.com (if email address verification is not possible for some reason).

This switches our Dockerfiles to use only `keyserver.ubuntu.com`, as `hkps://keys.openpgp.org` does not seem to work in our case.