### PR TITLE
update GPG keys from main repositories KEYS.txt file

### DIFF
--- a/baseDockerfile
+++ b/baseDockerfile
@@ -15,18 +15,16 @@ ENV JETTY_GPG_KEYS \
 	2A684B57436A81FA8706B53C61C3351A438A3B7D \
 	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
 	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
-	# Joakim Erdfelt  <joakim@apache.org>
+	# Joakim Erdfelt  <joakime@apache.org>
 	B59B67FD7904984367F931800818D9D68FB67BAC \
 	# Joakim Erdfelt  <joakim@erdfelt.com>
 	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
 	# Simone Bordet   <simone.bordet@gmail.com>
 	8B096546B1A8F02656B15D3B1677D141BCF3584D \
-	# Greg Wilkins    <gregw@webtide.com>
-	FBA2B18D238AB852DF95745C76157BDF03D0DCD6 \
-	# Greg Wilkins    <gregw@webtide.com>
-	5C9579B3DB2E506429319AAEF33B071B29559E1E \
-	# Olivier Lamy <olamy@apache.org>
-	F254B35617DC255D9344BCFA873A8E86B4372146
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
 
 RUN set -xe ; \
 	#

--- a/baseDockerfile-alpine
+++ b/baseDockerfile-alpine
@@ -15,18 +15,16 @@ ENV JETTY_GPG_KEYS \
 	2A684B57436A81FA8706B53C61C3351A438A3B7D \
 	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
 	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
-	# Joakim Erdfelt  <joakim@apache.org>
+	# Joakim Erdfelt  <joakime@apache.org>
 	B59B67FD7904984367F931800818D9D68FB67BAC \
 	# Joakim Erdfelt  <joakim@erdfelt.com>
 	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
 	# Simone Bordet   <simone.bordet@gmail.com>
 	8B096546B1A8F02656B15D3B1677D141BCF3584D \
-	# Greg Wilkins    <gregw@webtide.com>
-	FBA2B18D238AB852DF95745C76157BDF03D0DCD6 \
-	# Greg Wilkins    <gregw@webtide.com>
-	5C9579B3DB2E506429319AAEF33B071B29559E1E \
-	# Olivier Lamy <olamy@apache.org>
-	F254B35617DC255D9344BCFA873A8E86B4372146
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
 
 RUN set -xe ; \
 	mkdir -p $TMPDIR ; \

--- a/baseDockerfile-amazoncorretto
+++ b/baseDockerfile-amazoncorretto
@@ -15,18 +15,16 @@ ENV JETTY_GPG_KEYS \
 	2A684B57436A81FA8706B53C61C3351A438A3B7D \
 	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
 	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
-	# Joakim Erdfelt  <joakim@apache.org>
+	# Joakim Erdfelt  <joakime@apache.org>
 	B59B67FD7904984367F931800818D9D68FB67BAC \
 	# Joakim Erdfelt  <joakim@erdfelt.com>
 	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
 	# Simone Bordet   <simone.bordet@gmail.com>
 	8B096546B1A8F02656B15D3B1677D141BCF3584D \
-	# Greg Wilkins    <gregw@webtide.com>
-	FBA2B18D238AB852DF95745C76157BDF03D0DCD6 \
-	# Greg Wilkins    <gregw@webtide.com>
-	5C9579B3DB2E506429319AAEF33B071B29559E1E \
-	# Olivier Lamy <olamy@apache.org>
-	F254B35617DC255D9344BCFA873A8E86B4372146
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
 
 RUN set -xe ; \
 	#

--- a/baseDockerfile-slim
+++ b/baseDockerfile-slim
@@ -15,18 +15,16 @@ ENV JETTY_GPG_KEYS \
 	2A684B57436A81FA8706B53C61C3351A438A3B7D \
 	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
 	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
-	# Joakim Erdfelt  <joakim@apache.org>
+	# Joakim Erdfelt  <joakime@apache.org>
 	B59B67FD7904984367F931800818D9D68FB67BAC \
 	# Joakim Erdfelt  <joakim@erdfelt.com>
 	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
 	# Simone Bordet   <simone.bordet@gmail.com>
 	8B096546B1A8F02656B15D3B1677D141BCF3584D \
-	# Greg Wilkins    <gregw@webtide.com>
-	FBA2B18D238AB852DF95745C76157BDF03D0DCD6 \
-	# Greg Wilkins    <gregw@webtide.com>
-	5C9579B3DB2E506429319AAEF33B071B29559E1E \
-	# Olivier Lamy <olamy@apache.org>
-	F254B35617DC255D9344BCFA873A8E86B4372146
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
 
 RUN set -xe ; \
 	# Save initial installation state


### PR DESCRIPTION
update to use only GPG keys from this file https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/KEYS.txt