### PR TITLE
exec jetty.start from file to preserve quoted arguments

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			exec $JAVA $JAVA_OPTIONS "$@"
+			exec $JAVA $JAVA_OPTIONS "$@" $JETTY_PROPERTIES
 		esac
 	done
 
@@ -88,11 +88,13 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			/generate-jetty-start.sh "$@"
 		fi
 		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
-		set -- $(cat $JETTY_START)
 	else
 		/generate-jetty-start.sh "$@"
-		set -- $(cat $JETTY_START)
 	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
 fi
 
 if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 		DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
-		echo "$DRY_RUN" \
+		echo "exec $DRY_RUN" \
 			| egrep '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 			| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//' \
 			> $JETTY_START


### PR DESCRIPTION
exec the jetty.start from a file as in 10.0.15 there are quoted args in the --dry-run output which do not work when reading into a variable.

also introduce optional $JETTY_PROPERTIES environment variable which can be used to add jetty properties from docker image like this
```
ENV JETTY_PROPERTIES="jetty.http.port=8181"
```