### PR TITLE
Issue #141 - allow the dry-run to take in $JAVA_OPTIONS to put in jetty.start file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,7 +61,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			exec $JAVA $JAVA_OPTIONS "$@" $JETTY_PROPERTIES
+			exec $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES
 		esac
 	done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,6 +61,8 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
+			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
+			# the second one is used when generating the --dry-run output.
 			exec $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES
 		esac
 	done


### PR DESCRIPTION
## Issue #141

After PR #140 we now exec directly from the `jetty.start` file as the command returned from `--dry-run` now has quoted args that don't work well in shell variables.

So now we need the output of `--dry-run` to include the `$JAVA_OPTIONS` in its generated command.

the first `$JAVA_OPTIONS` if for the JVM which will do the dry run, the second one is used when generating the `--dry-run` output.
```sh
exec $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES
```
