### PR TITLE
Revert PR #155, use eval exec on terminating commands

### DIFF
--- a/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
@@ -63,8 +63,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			shift
 			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
 			# the second one is used when generating the --dry-run output.
-			echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
-			. $JETTY_BASE/jetty.exec
+			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 


### PR DESCRIPTION
Reverts eclipse/jetty.docker#155

after additional testing it was determined that
```
echo "exec " $JAVA $JAVA_OPTIONS "$@" $JAVA_OPTIONS $JETTY_PROPERTIES > $JETTY_BASE/jetty.exec
			. $JETTY_BASE/jetty.exec
```

will fix one use case but cause other issues.