### PR TITLE
separate the JVM options for --dry-run to the options used to run the server

### DIFF
--- a/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/10.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/11.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/12.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/12.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk8-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/amazoncorretto/9.4/jdk8/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk8/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/10.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/10.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/11.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/11.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/12.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/azul/zulu-openjdk/9.4/jdk8/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/10.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/11.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/12.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jdk8/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk8/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre17/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre8-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
@@ -61,9 +61,9 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 			# It is a terminating command, so exec directly
 			JAVA="$1"
 			shift
-			# The first $JAVA_OPTIONS is for the JVM which will do the --dry-run,
-			# the second one is used when generating the --dry-run output.
-			eval "exec $JAVA $JAVA_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
 		esac
 	done
 

--- a/eclipse-temurin/9.4/jre8/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre8/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -5,7 +5,7 @@ if [ -z "$JETTY_START" ] ; then
 fi
 rm -f $JETTY_START
 
-DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run)
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')

--- a/src/test/java/JavaOptionsTest.java
+++ b/src/test/java/JavaOptionsTest.java
@@ -6,6 +6,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -58,7 +59,8 @@ public class JavaOptionsTest
             httpClient.stop();
     }
 
-    @ParameterizedTest(name = "{0}")
+    @DisplayName("testSystemPropertyWithSpaces")
+    @ParameterizedTest(name = "{displayName}: {0}")
     @MethodSource("getImageTags")
     public void testSystemPropertyWithSpaces(String imageTag) throws Exception
     {
@@ -77,7 +79,8 @@ public class JavaOptionsTest
     }
 
     @Disabled("https://github.com/eclipse/jetty.docker/issues/153")
-    @ParameterizedTest(name = "{0}")
+    @DisplayName("testMultiLineJavaOpts")
+    @ParameterizedTest(name = "{displayName}: {0}")
     @MethodSource("getImageTags")
     public void testMultiLineJavaOpts(String imageTag) throws Exception
     {
@@ -112,7 +115,8 @@ public class JavaOptionsTest
         assertThat(log, containsString("org.eclipse.jetty.server.Request.maxFormContentSize = 2000000 (<command-line>)"));
     }
 
-    @ParameterizedTest()
+    @DisplayName("testRemoteJvmDebug")
+    @ParameterizedTest(name = "{displayName}: {0}")
     @MethodSource("getImageTags")
     public void testRemoteJvmDebug(String imageTag) throws Exception
     {

--- a/src/test/java/WelcomeFileTest.java
+++ b/src/test/java/WelcomeFileTest.java
@@ -12,6 +12,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -90,7 +91,8 @@ public class WelcomeFileTest
         return null;
     }
 
-    @ParameterizedTest(name = "{0}")
+    @DisplayName("testJettyDockerImage")
+    @ParameterizedTest(name = "{displayName}: {0}")
     @MethodSource("getImageTags")
     public void testJettyDockerImage(String imageTag) throws Exception
     {


### PR DESCRIPTION
add a new ENV option called `START_OPTIONS`

the `JAVA_OPTIONS` is used for the JVM which runs the server
and `START_OPTIONS` is used for the JVM used to generate the `--dry-run` command


this PR also has a change to send the `--dry-run` output to stderr