### PR TITLE
Introduce amazoncorretto al2023 images for JDK17 & JDK21

### DIFF
--- a/amazoncorretto/12.1/jdk17-al2023/Dockerfile
+++ b/amazoncorretto/12.1/jdk17-al2023/Dockerfile
@@ -1,0 +1,86 @@
+# DO NOT EDIT. Edit baseDockerfile-amazoncorretto and use update.sh
+FROM amazoncorretto:17-al2023
+
+ENV JETTY_VERSION 12.1.9
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utilities needed for setup.
+	yum install -y shadow-utils tar xz gzip which && yum clean all ; \
+	command -v dnf && dnf swap -y gnupg2-minimal gnupg2-full && dnf clean all ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/amazoncorretto/12.1/jdk17-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.1/jdk17-al2023/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/amazoncorretto/12.1/jdk17-al2023/generate-jetty-start.sh
+++ b/amazoncorretto/12.1/jdk17-al2023/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/amazoncorretto/12.1/jdk21-al2023/Dockerfile
+++ b/amazoncorretto/12.1/jdk21-al2023/Dockerfile
@@ -1,0 +1,86 @@
+# DO NOT EDIT. Edit baseDockerfile-amazoncorretto and use update.sh
+FROM amazoncorretto:21-al2023
+
+ENV JETTY_VERSION 12.1.9
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utilities needed for setup.
+	yum install -y shadow-utils tar xz gzip which && yum clean all ; \
+	command -v dnf && dnf swap -y gnupg2-minimal gnupg2-full && dnf clean all ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/amazoncorretto/12.1/jdk21-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.1/jdk21-al2023/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/amazoncorretto/12.1/jdk21-al2023/generate-jetty-start.sh
+++ b/amazoncorretto/12.1/jdk21-al2023/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -22,6 +22,7 @@ aliases=(
 	[eclipse-temurin-12.1-jdk25]='latest jdk25'
 	[eclipse-temurin-12.1-jdk21]='jdk21'
 	[eclipse-temurin-12.1-jdk17]='jdk17'
+	[amazoncorretto-12.0-jdk25-al2023]='12.0-amazoncorretto 12.0-jdk25-amazoncorretto'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
## Closes #284

- Introduce amazoncorretto al2023 images for JDK17 & JDK21
- Add `12.0-amazoncorretto` and `12.0-jdk25-amazoncorretto` tags for the 12.0 jdk25-amazoncorretto image.